### PR TITLE
Return usize instead of i32

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,13 +28,13 @@
 ///
 /// edit_distance("kitten", "sitting"); // => 3
 /// ```
-pub fn edit_distance(a: &str, b: &str) -> i32 {
+pub fn edit_distance(a: &str, b: &str) -> usize {
 
     let len_a = a.chars().count();
     let len_b = b.chars().count();
 
-    let row: Vec<i32> = vec![0; len_b + 1];
-    let mut matrix: Vec<Vec<i32>> = vec![row; len_a + 1];
+    let row: Vec<usize> = vec![0; len_b + 1];
+    let mut matrix: Vec<Vec<usize>> = vec![row; len_a + 1];
 
     // initialize string a
     for i in 0..len_a {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -47,10 +47,13 @@ use quickcheck::quickcheck;
 #[test]
 fn at_least_size_difference_property() {
     fn at_least_size_difference(a: String, b: String) -> bool {
-        let size_a = a.chars().count() as i32;
-        let size_b = b.chars().count() as i32;
-        let diff = (size_a - size_b).abs();
-
+        let size_a = a.chars().count();
+        let size_b = b.chars().count();
+        let diff = if size_a > size_b {
+          size_a - size_b
+        } else {
+          size_b - size_a
+        };
         edit_distance::edit_distance(&a, &b) >= diff
     }
 
@@ -64,7 +67,7 @@ fn at_most_length_of_longer_property() {
                             b.chars().count()]
             .iter()
             .max()
-            .unwrap() as i32;
+            .unwrap();
         edit_distance::edit_distance(&a, &b) <= upper_bound
     }
 


### PR DESCRIPTION
I believe this is correct, since the edit distance can be greater than
i32, and may never be negative.

This is a breaking change for users of the library. For strict semver compliance, it should bump the library to 2.0.0.