### PR TITLE
feat: Sequence support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,13 @@ keywords = ["text-processing", "search", "spelling"]
 license = "Apache-2.0"
 
 [dev-dependencies]
+criterion = "0.5.1"
 quickcheck = "^0"
+
+[[bench]]
+name = "edit_distance_sequences"
+harness = false
+
+[[bench]]
+name = "edit_distance"
+harness = false

--- a/benches/edit_distance.rs
+++ b/benches/edit_distance.rs
@@ -1,0 +1,17 @@
+extern crate criterion;
+extern crate edit_distance;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use edit_distance::edit_distance;
+
+pub fn benchmark_edit_distance(c: &mut Criterion) {
+    let a = "kitten";
+    let b = "sitting";
+
+    c.bench_function("edit_distance", |bencher| {
+        bencher.iter(|| edit_distance(black_box(a), black_box(b)))
+    });
+}
+
+criterion_group!(benches, benchmark_edit_distance);
+criterion_main!(benches);

--- a/benches/edit_distance_sequences.rs
+++ b/benches/edit_distance_sequences.rs
@@ -1,0 +1,17 @@
+extern crate criterion;
+extern crate edit_distance;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use edit_distance::edit_distance_sequences;
+
+pub fn benchmark_edit_distance_sequences(c: &mut Criterion) {
+    let b = "sitting".chars().collect::<Vec<_>>();
+    let a = "kitten".chars().collect::<Vec<_>>();
+
+    c.bench_function("edit_distance_sequences", |bencher| {
+        bencher.iter(|| edit_distance_sequences(black_box(&a), black_box(&b)))
+    });
+}
+
+criterion_group!(benches, benchmark_edit_distance_sequences);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,11 @@
 
 //! # Edit distance
 //!
-//! The [Levenshtein edit distance][wikipedia] between two strings is
-//! the number of individual single-character changes (insert, delete,
-//! substitute) necessary to change string `a` into `b`.
+//! The [Levenshtein edit distance][wikipedia] between two sequences is
+//! the number of individual single-element changes (insert, delete,
+//! substitute) necessary to change sequence `a` into `b`.
 //!
-//! This can be a used to order search results, for fuzzy
+//! This can be used to order search results, for fuzzy
 //! auto-completion, and to find candidates for spelling correction.
 //!
 //! ## References
@@ -26,14 +26,17 @@
 /// ```
 /// use edit_distance::edit_distance;
 ///
-/// edit_distance("kitten", "sitting"); // => 3
+/// assert_eq!(edit_distance("kitten", "sitting"), 3);
 /// ```
 pub fn edit_distance(a: &str, b: &str) -> usize {
     let len_a = a.chars().count();
     let len_b = b.chars().count();
+    let len_b_plus_one = len_b + 1;
+
     if len_a < len_b {
         return edit_distance(b, a);
     }
+
     // handle special case of 0 length
     if len_a == 0 {
         return len_b;
@@ -41,36 +44,76 @@ pub fn edit_distance(a: &str, b: &str) -> usize {
         return len_a;
     }
 
-    let len_b = len_b + 1;
-
-    let mut pre;
-    let mut tmp;
-    let mut cur = vec![0; len_b];
+    let mut cur = vec![0; len_b_plus_one];
 
     // initialize string b
-    for i in 1..len_b {
+    (1..len_b_plus_one).for_each(|i| {
         cur[i] = i;
-    }
+    });
 
     // calculate edit distance
     for (i, ca) in a.chars().enumerate() {
         // get first column for this row
-        pre = cur[0];
+        let mut pre = cur[0];
         cur[0] = i + 1;
         for (j, cb) in b.chars().enumerate() {
-            tmp = cur[j + 1];
-            cur[j + 1] = std::cmp::min(
-                // deletion
-                tmp + 1,
-                std::cmp::min(
-                    // insertion
-                    cur[j] + 1,
-                    // match or substitution
-                    pre + if ca == cb { 0 } else { 1 },
-                ),
-            );
+            let tmp = cur[j + 1];
+            cur[j + 1] = (tmp + 1)
+                .min(cur[j] + 1)
+                .min(pre + if ca == cb { 0 } else { 1 });
             pre = tmp;
         }
     }
-    cur[len_b - 1]
+
+    cur[len_b]
+}
+
+/// Returns the edit distance between sequences `a` and `b`.
+///
+/// The runtime complexity is `O(m*n)`, where `m` and `n` are the
+/// sequences' lengths.
+///
+/// # Examples
+///
+/// ```
+/// use edit_distance::edit_distance_sequences;
+///
+/// assert_eq!(edit_distance_sequences(&"kitten".chars().collect::<Vec<_>>(), &"sitting".chars().collect::<Vec<_>>()), 3);
+/// assert_eq!(edit_distance_sequences(&vec![1, 2, 3], &vec![2, 3, 4]), 2);
+/// ```
+pub fn edit_distance_sequences<T: PartialEq>(a: &[T], b: &[T]) -> usize {
+    let len_a = a.len();
+    let len_b = b.len();
+    if len_a < len_b {
+        return edit_distance_sequences(b, a);
+    }
+
+    // handle special case of 0 length
+    if len_a == 0 {
+        return len_b;
+    } else if len_b == 0 {
+        return len_a;
+    }
+
+    let mut cur = vec![0; len_b + 1];
+
+    // initialize sequence b
+    (1..=len_b).for_each(|i| {
+        cur[i] = i;
+    });
+
+    // calculate edit distance
+    for (i, ca) in a.iter().enumerate() {
+        let mut pre = cur[0];
+        cur[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let tmp = cur[j + 1];
+            cur[j + 1] = (tmp + 1)
+                .min(cur[j] + 1)
+                .min(pre + if ca == cb { 0 } else { 1 });
+            pre = tmp;
+        }
+    }
+
+    cur[len_b]
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,8 +7,38 @@ fn simple() {
 }
 
 #[test]
+fn simple_seq() {
+    assert_eq!(
+        edit_distance::edit_distance_sequences(
+            &"kitten".chars().collect::<Vec<_>>(),
+            &"sitting".chars().collect::<Vec<_>>()
+        ),
+        3
+    );
+    assert_eq!(
+        edit_distance::edit_distance_sequences(&[1, 2, 3], &[2, 3, 4]),
+        2
+    );
+}
+
+#[test]
 fn same() {
     assert_eq!(edit_distance::edit_distance("kitten", "kitten"), 0);
+}
+
+#[test]
+fn same_seq() {
+    assert_eq!(
+        edit_distance::edit_distance_sequences(
+            &"kitten".chars().collect::<Vec<_>>(),
+            &"kitten".chars().collect::<Vec<_>>()
+        ),
+        0
+    );
+    assert_eq!(
+        edit_distance::edit_distance_sequences(&[1, 2, 3], &[1, 2, 3]),
+        0
+    );
 }
 
 #[test]
@@ -17,8 +47,24 @@ fn empty_a() {
 }
 
 #[test]
+fn empty_a_seq() {
+    assert_eq!(
+        edit_distance::edit_distance_sequences(&[], &"kitten".chars().collect::<Vec<_>>()),
+        6
+    );
+}
+
+#[test]
 fn empty_b() {
     assert_eq!(edit_distance::edit_distance("sitting", ""), 7);
+}
+
+#[test]
+fn empty_b_seq() {
+    assert_eq!(
+        edit_distance::edit_distance_sequences(&"sitting".chars().collect::<Vec<_>>(), &[]),
+        7
+    );
 }
 
 #[test]
@@ -27,8 +73,25 @@ fn empty_both() {
 }
 
 #[test]
+fn empty_both_seq() {
+    assert_eq!(edit_distance::edit_distance_sequences::<char>(&[], &[]), 0);
+    assert_eq!(edit_distance::edit_distance_sequences::<i32>(&[], &[]), 0);
+}
+
+#[test]
 fn unicode_misc() {
     assert_eq!(edit_distance::edit_distance("üö", "uo"), 2);
+}
+
+#[test]
+fn unicode_misc_seq() {
+    assert_eq!(
+        edit_distance::edit_distance_sequences(
+            &"üö".chars().collect::<Vec<_>>(),
+            &"uo".chars().collect::<Vec<_>>()
+        ),
+        2
+    );
 }
 
 #[test]
@@ -37,9 +100,28 @@ fn unicode_thai() {
 }
 
 #[test]
-fn unicode_misc_equal() {
+fn unicode_thai_seq() {
     assert_eq!(
-        edit_distance::edit_distance("☀☂☃☄", "☀☂☃☄"),
+        edit_distance::edit_distance_sequences(
+            &"ฎ ฏ ฐ".chars().collect::<Vec<_>>(),
+            &"a b c".chars().collect::<Vec<_>>()
+        ),
+        3
+    );
+}
+
+#[test]
+fn unicode_misc_equal() {
+    assert_eq!(edit_distance::edit_distance("☀☂☃☄", "☀☂☃☄"), 0);
+}
+
+#[test]
+fn unicode_misc_equal_seq() {
+    assert_eq!(
+        edit_distance::edit_distance_sequences(
+            &"☀☂☃☄".chars().collect::<Vec<_>>(),
+            &"☀☂☃☄".chars().collect::<Vec<_>>()
+        ),
         0
     );
 }
@@ -64,6 +146,22 @@ fn at_least_size_difference_property() {
 }
 
 #[test]
+fn at_least_size_difference_property_seq() {
+    fn at_least_size_difference(a: Vec<u32>, b: Vec<u32>) -> bool {
+        let size_a = a.len();
+        let size_b = b.len();
+        let diff = if size_a > size_b {
+            size_a - size_b
+        } else {
+            size_b - size_a
+        };
+        edit_distance::edit_distance_sequences(&a, &b) >= diff
+    }
+
+    quickcheck(at_least_size_difference as fn(a: Vec<u32>, b: Vec<u32>) -> bool);
+}
+
+#[test]
 fn at_most_length_of_longer_property() {
     fn at_most_size_of_longer(a: String, b: String) -> bool {
         let upper_bound = *[a.chars().count(), b.chars().count()].iter().max().unwrap();
@@ -71,6 +169,16 @@ fn at_most_length_of_longer_property() {
     }
 
     quickcheck(at_most_size_of_longer as fn(a: String, b: String) -> bool);
+}
+
+#[test]
+fn at_most_length_of_longer_property_seq() {
+    fn at_most_size_of_longer(a: Vec<u32>, b: Vec<u32>) -> bool {
+        let upper_bound = *[a.len(), b.len()].iter().max().unwrap();
+        edit_distance::edit_distance_sequences(&a, &b) <= upper_bound
+    }
+
+    quickcheck(at_most_size_of_longer as fn(a: Vec<u32>, b: Vec<u32>) -> bool);
 }
 
 #[test]
@@ -89,6 +197,21 @@ fn zero_iff_a_equals_b_property() {
 }
 
 #[test]
+fn zero_iff_a_equals_b_property_seq() {
+    fn zero_iff_a_equals_b(a: Vec<u32>, b: Vec<u32>) -> bool {
+        let d = edit_distance::edit_distance_sequences(&a, &b);
+
+        if a == b {
+            d == 0
+        } else {
+            d > 0
+        }
+    }
+
+    quickcheck(zero_iff_a_equals_b as fn(a: Vec<u32>, b: Vec<u32>) -> bool);
+}
+
+#[test]
 fn triangle_inequality_property() {
     fn triangle_inequality(a: String, b: String, c: String) -> bool {
         edit_distance::edit_distance(&a, &b)
@@ -96,4 +219,15 @@ fn triangle_inequality_property() {
     }
 
     quickcheck(triangle_inequality as fn(a: String, b: String, c: String) -> bool);
+}
+
+#[test]
+fn triangle_inequality_property_sequences() {
+    fn triangle_inequality(a: Vec<u32>, b: Vec<u32>, c: Vec<u32>) -> bool {
+        edit_distance::edit_distance_sequences(&a, &b)
+            <= edit_distance::edit_distance_sequences(&a, &c)
+                + edit_distance::edit_distance_sequences(&b, &c)
+    }
+
+    quickcheck(triangle_inequality as fn(a: Vec<u32>, b: Vec<u32>, c: Vec<u32>) -> bool);
 }


### PR DESCRIPTION
Hi.

I have made some refactoring and performance improvements within the existing function. I provided the necessary enhancements for benchmarking. I added a `edit_distance_sequences<T: PartialEq>(a: &[T], b: &[T]) -> usize` variant for a more generic approach. I also ensured the improvement of the tests required for this variant I have written.

For backward compatibility, I did not change the signature of the existing function. I am aware of the repetitive code, but I preferred to keep it this way because I observed a negative impact on performance when separating them into functions.

Lastly, I am relatively new to Rust programming :) Please don't hesitate to let me know if there is anything I can improve.